### PR TITLE
Update travis.yml with Filler exclude

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python: 2.7
 sudo: false
 script:
 # won't fail, but print problems
-- find . -name "*.json" -exec echo {} \; -exec python -mjson.tool {} /dev/null \; 2>&1 |grep --before 1 "Expecting" | cat
+- find . -name "*.json" -not -name "*Filler.json" -exec echo {} \; -exec python -mjson.tool {} /dev/null \; 2>&1 |grep -v -B 1 "^\./"
 # will fail, if linting fails
-- find . -name "*.json" -print0 | xargs -I file -n1 -0 python -mjson.tool file /dev/null 
+- find . -name "*.json" -not -name "*Filler.json" -print0 | xargs -I file -n1 -0 python -mjson.tool file /dev/null 


### PR DESCRIPTION
Based on issue#169 i have updated the travis configuration to:

- Excluded *Filler.json from checking
- Excluded *Filler.json from linting
- Print all "lines not starting with "./" and the line before" containing the affected file and error close together.